### PR TITLE
Fix error unregistering addon

### DIFF
--- a/spring_bones.py
+++ b/spring_bones.py
@@ -864,7 +864,7 @@ def unregister():
     del bpy.types.Object.sb_object_collider
     del bpy.types.Object.sb_collider_dist
     del bpy.types.Object.sb_collider_force
-    del bpy.types.Object.sb_collide
+    del bpy.types.PoseBone.sb_collide
     del bpy.types.PoseBone.sb_global_influence
     
     


### PR DESCRIPTION
Error caused by removing non-existing property.

Example error:
```
Error: Traceback (most recent call last):
  File "\Blender\4.3\scripts\modules\addon_utils.py", line 562, in disable
    mod.unregister()
  File "\AppData\Roaming\Blender Foundation\Blender\4.3\scripts\addons\spring_bones.py", line 867, in unregister
    del bpy.types.Object.sb_collide
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'Object' has no attribute 'sb_collide'
```

@artellblender